### PR TITLE
lib: fix memory leak when handling I/O

### DIFF
--- a/src/lib/atom.h
+++ b/src/lib/atom.h
@@ -55,11 +55,10 @@ struct lldpctl_conn_t {
 #define CONN_STATE_GET_DEFAULT_PORT_SEND 15
 #define CONN_STATE_GET_DEFAULT_PORT_RECV 16
 	int state;		/* Current state */
-	char *state_data;	/* Data attached to the state. It is used to
-				 * check that we are using the same data as a
-				 * previous call until the state machine goes to
-				 * CONN_STATE_IDLE. */
-
+	/* Data attached to the state. It is used to check that we are using the
+	 * same data as a previous call until the state machine goes to
+	 * CONN_STATE_IDLE. */
+	char state_data[IFNAMSIZ + 64];
 	/* Error handling */
 	lldpctl_error_t error;	/* Last error */
 

--- a/src/lib/atoms/port.c
+++ b/src/lib/atoms/port.c
@@ -329,7 +329,7 @@ _lldpctl_atom_set_atom_port(lldpctl_atom_t *atom, lldpctl_key_t key, lldpctl_ato
 	struct lldpd_hardware *hardware = p->hardware;
 	struct lldpd_port_set set = {};
 	int rc;
-	char *canary;
+	char *canary = NULL;
 
 #ifdef ENABLE_DOT3
 	struct _lldpctl_atom_dot3_power_t *dpow;


### PR DESCRIPTION
The state data is used to ensure we don't interleave requests of the
same kind (eg requesting data for eth0, then for eth1 while eth0 is
running). The data was freed only when reaching `CONN_STATE_IDLE`
again. Otherwise, there was a memory leak.

To avoid the memory leak, we avoid use a static allocation instead.

Fix #362.